### PR TITLE
feat: replace service process adaptor methods by closure

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -77,7 +77,7 @@ where
                                 .get_string(10)
                                 .unwrap_or(Cow::Owned(String::from("empty body")));
                             <HyperDemoAdaptor as HyperServerAdaptor<M>>::response_builder(
-                                &adaptor,
+                                adaptor,
                                 StatusCode::OK,
                             )
                             .body(BoxBody::new(Full::new(Bytes::from(format!(
@@ -87,7 +87,7 @@ where
                         }
                         Err(err) => default_srv_error_response(&err, |s| {
                             <HyperDemoAdaptor as HyperServerAdaptor<M>>::response_builder(
-                                &adaptor, s,
+                                adaptor, s,
                             )
                         }),
                     }),

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::convert::Infallible;
+
 use std::env;
 
 use bytes::Bytes;
@@ -7,7 +7,7 @@ use clap::{ArgAction, Command, arg};
 use config::Config;
 use http_body_util::Full;
 use http_body_util::combinators::BoxBody;
-use hyper::{Request, Response};
+use hyper::{Request, Response, StatusCode};
 use prosa::core::adaptor::Adaptor;
 use prosa::core::error::ProcError;
 use prosa::core::main::MainRunnable as _;
@@ -16,9 +16,9 @@ use prosa::core::settings::settings;
 use prosa::stub::adaptor::StubParotAdaptor;
 use prosa::stub::proc::StubSettings;
 use prosa::{core::main::MainProc, stub::proc::StubProc};
-use prosa_hyper::server::adaptor::HyperServerAdaptor;
+use prosa_hyper::server::adaptor::{HyperServerAdaptor, default_srv_error_response};
 use prosa_hyper::server::proc::{HyperServerProc, HyperServerSettings};
-use prosa_hyper::{HttpError, HyperResp, PRODUCT_VERSION_HEADER};
+use prosa_hyper::{HyperResp, PRODUCT_VERSION_HEADER};
 use prosa_utils::config::tracing::TelemetryFilter;
 use prosa_utils::msg::simple_string_tvf::SimpleStringTvf;
 use serde::{Deserialize, Serialize};
@@ -50,7 +50,7 @@ where
     async fn process_http_request(
         &self,
         req: Request<hyper::body::Incoming>,
-    ) -> crate::HyperResp<M> {
+    ) -> crate::HyperResp<Self, M> {
         match req.uri().path() {
             "/" => Response::builder()
                 .header("Server", PRODUCT_VERSION_HEADER)
@@ -68,7 +68,30 @@ where
                 let mut tvf_req = M::default();
                 tvf_req.put_string(1, req.method().to_string());
                 tvf_req.put_string(2, "/test");
-                HyperResp::SrvReq(String::from("SRV_TEST"), tvf_req)
+                HyperResp::SrvReq(
+                    String::from("SRV_TEST"),
+                    tvf_req,
+                    Box::new(move |adaptor, result| match result {
+                        Ok(resp) => {
+                            let body = resp
+                                .get_string(10)
+                                .unwrap_or(Cow::Owned(String::from("empty body")));
+                            <HyperDemoAdaptor as HyperServerAdaptor<M>>::response_builder(
+                                &adaptor,
+                                StatusCode::OK,
+                            )
+                            .body(BoxBody::new(Full::new(Bytes::from(format!(
+                                "Body: {body}\nTvfResp: {resp:?}"
+                            )))))
+                            .map_err(|e| e.into())
+                        }
+                        Err(err) => default_srv_error_response(&err, |s| {
+                            <HyperDemoAdaptor as HyperServerAdaptor<M>>::response_builder(
+                                &adaptor, s,
+                            )
+                        }),
+                    }),
+                )
             }
             _ => Response::builder()
                 .status(404)
@@ -76,20 +99,6 @@ where
                 .body(BoxBody::new(Full::new(Bytes::from("Not Found"))))
                 .into(),
         }
-    }
-
-    fn process_srv_response(
-        &self,
-        resp: M,
-    ) -> Result<Response<BoxBody<Bytes, Infallible>>, HttpError> {
-        let body = resp
-            .get_string(10)
-            .unwrap_or(Cow::Owned(String::from("empty body")));
-        Response::builder()
-            .body(BoxBody::new(Full::new(Bytes::from(format!(
-                "Body: {body}\nTvfResp: {resp:?}"
-            )))))
-            .map_err(|e| e.into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use http_body_util::combinators::BoxBody;
 use hyper::{Response, Version};
 use prosa::core::{
     error::{BusError, ProcError},
-    msg::InternalMsg,
+    msg::{ErrorMsg, InternalMsg},
 };
 use thiserror::Error;
 
@@ -110,36 +110,128 @@ fn hyper_version_str(version: Version) -> &'static str {
     }
 }
 
+/// Type alias for the closure that processes an internal service response or error.
+///
+/// Receives `Ok(M)` on success or `Err(ErrorMsg<M>)` on service error.
+/// Returns an HTTP response or an HTTP error.
+pub type SrvRespHandler<A, M> = Box<
+    dyn FnOnce(
+            &A,
+            Result<M, ErrorMsg<M>>,
+        ) -> Result<Response<BoxBody<Bytes, Infallible>>, HttpError>
+        + Send,
+>;
+
 /// Enum to define all type of response to request it can be made
-#[derive(Debug)]
-pub enum HyperResp<M> {
-    /// Make an internal service request to have a response
-    SrvReq(String, M),
+pub enum HyperResp<A, M>
+where
+    A: server::adaptor::HyperServerAdaptor<M>,
+    M: 'static
+        + std::marker::Send
+        + std::marker::Sync
+        + std::marker::Sized
+        + std::clone::Clone
+        + std::fmt::Debug
+        + prosa::core::msg::Tvf
+        + std::default::Default,
+{
+    /// Make an internal service request and process the response with the provided handler
+    SrvReq(String, M, SrvRespHandler<A, M>),
     /// Make a direct HTTP response
     HttpResp(Response<BoxBody<Bytes, Infallible>>),
     /// Response with an HTTP error
     HttpErr(HttpError),
 }
 
-impl<M> From<HttpError> for HyperResp<M> {
+impl<A, M> std::fmt::Debug for HyperResp<A, M>
+where
+    A: server::adaptor::HyperServerAdaptor<M>,
+    M: 'static
+        + std::marker::Send
+        + std::marker::Sync
+        + std::marker::Sized
+        + std::clone::Clone
+        + std::fmt::Debug
+        + prosa::core::msg::Tvf
+        + std::default::Default,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HyperResp::SrvReq(name, msg, _) => f
+                .debug_tuple("SrvReq")
+                .field(name)
+                .field(msg)
+                .field(&"<handler>")
+                .finish(),
+            HyperResp::HttpResp(resp) => f.debug_tuple("HttpResp").field(resp).finish(),
+            HyperResp::HttpErr(err) => f.debug_tuple("HttpErr").field(err).finish(),
+        }
+    }
+}
+
+impl<A, M> From<HttpError> for HyperResp<A, M>
+where
+    A: server::adaptor::HyperServerAdaptor<M>,
+    M: 'static
+        + std::marker::Send
+        + std::marker::Sync
+        + std::marker::Sized
+        + std::clone::Clone
+        + std::fmt::Debug
+        + prosa::core::msg::Tvf
+        + std::default::Default,
+{
     fn from(err: HttpError) -> Self {
         Self::HttpErr(err)
     }
 }
 
-impl<M> From<hyper::Error> for HyperResp<M> {
+impl<A, M> From<hyper::Error> for HyperResp<A, M>
+where
+    A: server::adaptor::HyperServerAdaptor<M>,
+    M: 'static
+        + std::marker::Send
+        + std::marker::Sync
+        + std::marker::Sized
+        + std::clone::Clone
+        + std::fmt::Debug
+        + prosa::core::msg::Tvf
+        + std::default::Default,
+{
     fn from(err: hyper::Error) -> Self {
         Self::HttpErr(HttpError::Hyper(err))
     }
 }
 
-impl<M> From<http::Error> for HyperResp<M> {
+impl<A, M> From<http::Error> for HyperResp<A, M>
+where
+    A: server::adaptor::HyperServerAdaptor<M>,
+    M: 'static
+        + std::marker::Send
+        + std::marker::Sync
+        + std::marker::Sized
+        + std::clone::Clone
+        + std::fmt::Debug
+        + prosa::core::msg::Tvf
+        + std::default::Default,
+{
     fn from(err: http::Error) -> Self {
         Self::HttpErr(HttpError::Http(err))
     }
 }
 
-impl<M> From<Result<Response<BoxBody<Bytes, Infallible>>, http::Error>> for HyperResp<M> {
+impl<A, M> From<Result<Response<BoxBody<Bytes, Infallible>>, http::Error>> for HyperResp<A, M>
+where
+    A: server::adaptor::HyperServerAdaptor<M>,
+    M: 'static
+        + std::marker::Send
+        + std::marker::Sync
+        + std::marker::Sized
+        + std::clone::Clone
+        + std::fmt::Debug
+        + prosa::core::msg::Tvf
+        + std::default::Default,
+{
     fn from(res: Result<Response<BoxBody<Bytes, Infallible>>, http::Error>) -> Self {
         match res {
             Ok(response) => Self::HttpResp(response),

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,7 +33,7 @@ mod tests {
     use url::Url;
 
     use crate::{
-        HttpError, HyperResp,
+        HyperResp,
         server::{adaptor::HyperServerAdaptor, proc::HyperServerProc},
         tests::HttpTestSettings,
     };
@@ -65,7 +65,10 @@ mod tests {
             Ok(ServerTestAdaptor {})
         }
 
-        async fn process_http_request(&self, req: Request<hyper::body::Incoming>) -> HyperResp<M> {
+        async fn process_http_request(
+            &self,
+            req: Request<hyper::body::Incoming>,
+        ) -> HyperResp<Self, M> {
             let resp_msg = if req.version() == hyper::Version::HTTP_2 {
                 "Hello, H2 world"
             } else {
@@ -74,18 +77,6 @@ mod tests {
             <ServerTestAdaptor as HyperServerAdaptor<M>>::response_builder(self, StatusCode::OK)
                 .body(BoxBody::new(Full::new(Bytes::from(resp_msg))))
                 .into()
-        }
-
-        fn process_srv_response(
-            &self,
-            _resp: M,
-        ) -> Result<
-            hyper::Response<
-                http_body_util::combinators::BoxBody<bytes::Bytes, std::convert::Infallible>,
-            >,
-            HttpError,
-        > {
-            unimplemented!()
         }
     }
 

--- a/src/server/adaptor.rs
+++ b/src/server/adaptor.rs
@@ -54,36 +54,61 @@ where
     fn process_http_request(
         &self,
         req: Request<hyper::body::Incoming>,
-    ) -> impl std::future::Future<Output = HyperResp<M>> + Send;
+    ) -> impl std::future::Future<Output = HyperResp<Self, M>> + Send
+    where
+        Self: Sized + Send + Sync + 'static,
+        M: 'static
+            + Send
+            + Sync
+            + Sized
+            + Clone
+            + std::fmt::Debug
+            + prosa::core::msg::Tvf
+            + Default;
+}
 
-    /// Method to process input response to respond with an Hyper HTTP response.
-    fn process_srv_response(
-        &self,
-        resp: M,
-    ) -> Result<Response<BoxBody<Bytes, Infallible>>, HttpError>;
-
-    /// Method to process input service error to respond with an Hyper HTTP response.
-    fn process_srv_error(
-        &self,
-        err: ErrorMsg<M>,
-    ) -> Result<Response<BoxBody<Bytes, Infallible>>, HttpError> {
-        match err.get_err() {
-            prosa::core::service::ServiceError::NoError(_) => self
-                .response_builder(StatusCode::ACCEPTED)
-                .body(BoxBody::new(Empty::<Bytes>::new()))
-                .map_err(|e| e.into()),
-            prosa::core::service::ServiceError::UnableToReachService(_) => self
-                .response_builder(StatusCode::SERVICE_UNAVAILABLE)
+/// Convert a service error message into a default HTTP response.
+///
+/// This provides a default mapping from [`prosa::core::service::ServiceError`] variants to HTTP status codes:
+/// - `NoError` -> `202 Accepted`
+/// - `UnableToReachService` -> `503 Service Unavailable`
+/// - `Timeout` -> `504 Gateway Timeout`
+/// - `ProtocolError` -> `502 Bad Gateway`
+///
+/// The `response_builder` parameter allows customizing the response headers (e.g., adding a `Server` header).
+pub fn default_srv_error_response<M, F>(
+    err: &ErrorMsg<M>,
+    response_builder: F,
+) -> Result<Response<BoxBody<Bytes, Infallible>>, HttpError>
+where
+    M: 'static
+        + std::marker::Send
+        + std::marker::Sync
+        + std::marker::Sized
+        + std::clone::Clone
+        + std::fmt::Debug
+        + prosa::core::msg::Tvf
+        + std::default::Default,
+    F: Fn(StatusCode) -> response::Builder,
+{
+    match err.get_err() {
+        prosa::core::service::ServiceError::NoError(_) => response_builder(StatusCode::ACCEPTED)
+            .body(BoxBody::new(Empty::<Bytes>::new()))
+            .map_err(|e| e.into()),
+        prosa::core::service::ServiceError::UnableToReachService(_) => {
+            response_builder(StatusCode::SERVICE_UNAVAILABLE)
                 .body(BoxBody::new(Full::new(Bytes::from("Can't reach service"))))
-                .map_err(|e| e.into()),
-            prosa::core::service::ServiceError::Timeout(_, _) => self
-                .response_builder(StatusCode::GATEWAY_TIMEOUT)
+                .map_err(|e| e.into())
+        }
+        prosa::core::service::ServiceError::Timeout(_, _) => {
+            response_builder(StatusCode::GATEWAY_TIMEOUT)
                 .body(BoxBody::new(Empty::<Bytes>::new()))
-                .map_err(|e| e.into()),
-            prosa::core::service::ServiceError::ProtocolError(_) => self
-                .response_builder(StatusCode::BAD_GATEWAY)
+                .map_err(|e| e.into())
+        }
+        prosa::core::service::ServiceError::ProtocolError(_) => {
+            response_builder(StatusCode::BAD_GATEWAY)
                 .body(BoxBody::new(Empty::<Bytes>::new()))
-                .map_err(|e| e.into()),
+                .map_err(|e| e.into())
         }
     }
 }
@@ -111,18 +136,14 @@ where
         })
     }
 
-    async fn process_http_request(&self, _req: Request<hyper::body::Incoming>) -> HyperResp<M> {
+    async fn process_http_request(
+        &self,
+        _req: Request<hyper::body::Incoming>,
+    ) -> HyperResp<Self, M> {
         Response::builder()
             .status(200)
             .header("Server", PRODUCT_VERSION_HEADER)
             .body(BoxBody::new(Full::new(Bytes::from(self.hello_msg.clone()))))
             .into()
-    }
-
-    fn process_srv_response(
-        &self,
-        _resp: M,
-    ) -> Result<Response<BoxBody<Bytes, Infallible>>, HttpError> {
-        panic!("No message should be send to an external service")
     }
 }

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -41,7 +41,7 @@ where
 
 impl<A, M> HyperService<A, M>
 where
-    A: 'static + HyperServerAdaptor<M> + Clone,
+    A: 'static + HyperServerAdaptor<M> + Clone + std::marker::Sync + std::marker::Send,
     M: 'static
         + std::marker::Send
         + std::marker::Sync
@@ -71,10 +71,11 @@ where
         metric_counter: Counter<u64>,
     ) -> Result<Response<BoxBody<Bytes, Infallible>>, HttpError> {
         match adaptor.process_http_request(req).await {
-            crate::HyperResp::SrvReq(srv_name, req) => {
-                let resp =
-                    HyperService::<A, M>::wait_intern_resp(adaptor, proc_queue, srv_name, req)
-                        .await;
+            crate::HyperResp::SrvReq(srv_name, req, handler) => {
+                let resp = HyperService::<A, M>::wait_intern_resp(
+                    adaptor, proc_queue, srv_name, req, handler,
+                )
+                .await;
                 if let Ok(ref res) = resp {
                     metric_counter.add(
                         1,
@@ -109,6 +110,7 @@ where
         proc_queue: mpsc::Sender<RequestMsg<M>>,
         service_name: String,
         request: M,
+        handler: crate::SrvRespHandler<A, M>,
     ) -> Result<Response<BoxBody<Bytes, Infallible>>, HttpError> {
         let (resp_tx, resp_rx) = oneshot::channel::<InternalMsg<M>>();
         let _ = proc_queue
@@ -119,14 +121,14 @@ where
             Ok(msg) => match msg {
                 InternalMsg::Response(mut msg) => {
                     if let Some(data) = msg.take_data() {
-                        adaptor.process_srv_response(data)
+                        handler(&adaptor, Ok(data))
                     } else {
                         Ok(adaptor
                             .response_builder(StatusCode::INTERNAL_SERVER_ERROR)
                             .body(BoxBody::new(Empty::<Bytes>::new()))?)
                     }
                 }
-                InternalMsg::Error(err) => adaptor.process_srv_error(err),
+                InternalMsg::Error(err) => handler(&adaptor, Err(err)),
                 _ => Ok(adaptor
                     .response_builder(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(BoxBody::new(Empty::<Bytes>::new()))?),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,9 +157,12 @@ mod tests {
     use url::Url;
 
     use crate::{
-        HttpError, HyperResp, PRODUCT_VERSION_HEADER,
+        HyperResp, PRODUCT_VERSION_HEADER,
         client::{adaptor::HyperClientAdaptor, proc::HyperClientProc},
-        server::{adaptor::HyperServerAdaptor, proc::HyperServerProc},
+        server::{
+            adaptor::{HyperServerAdaptor, default_srv_error_response},
+            proc::HyperServerProc,
+        },
         tests::HttpTestSettings,
     };
 
@@ -248,7 +251,10 @@ mod tests {
             Ok(TestAdaptor { test_type })
         }
 
-        async fn process_http_request(&self, req: Request<hyper::body::Incoming>) -> HyperResp<M> {
+        async fn process_http_request(
+            &self,
+            req: Request<hyper::body::Incoming>,
+        ) -> HyperResp<Self, M> {
             let mut srv_req = M::default();
 
             if let Some(user_agent) = req
@@ -265,33 +271,34 @@ mod tests {
                 srv_req.put_string(1, body_str);
             }
 
-            HyperResp::SrvReq("STUB_HTTP_SRV".into(), srv_req)
-        }
-
-        fn process_srv_response(
-            &self,
-            resp: M,
-        ) -> Result<
-            hyper::Response<
-                http_body_util::combinators::BoxBody<bytes::Bytes, std::convert::Infallible>,
-            >,
-            HttpError,
-        > {
-            if let Ok(content) = resp.get_string(1) {
-                Response::builder()
-                    .header(hyper::header::SERVER, PRODUCT_VERSION_HEADER)
-                    .status(StatusCode::OK)
-                    .body(BoxBody::new(Full::new(Bytes::from_owner(
-                        content.into_owned(),
-                    ))))
-                    .map_err(|e| e.into())
-            } else {
-                Response::builder()
-                    .header(hyper::header::SERVER, PRODUCT_VERSION_HEADER)
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(BoxBody::new(Full::new(Bytes::from("Bad Request"))))
-                    .map_err(|e| e.into())
-            }
+            HyperResp::SrvReq(
+                "STUB_HTTP_SRV".into(),
+                srv_req,
+                Box::new(move |adaptor, result| match result {
+                    Ok(resp) => {
+                        if let Ok(content) = resp.get_string(1) {
+                            <TestAdaptor as HyperServerAdaptor<M>>::response_builder(
+                                &adaptor,
+                                StatusCode::OK,
+                            )
+                            .body(BoxBody::new(Full::new(Bytes::from_owner(
+                                content.into_owned(),
+                            ))))
+                            .map_err(|e| e.into())
+                        } else {
+                            <TestAdaptor as HyperServerAdaptor<M>>::response_builder(
+                                &adaptor,
+                                StatusCode::BAD_REQUEST,
+                            )
+                            .body(BoxBody::new(Full::new(Bytes::from("Bad Request"))))
+                            .map_err(|e| e.into())
+                        }
+                    }
+                    Err(err) => default_srv_error_response(&err, |s| {
+                        <TestAdaptor as HyperServerAdaptor<M>>::response_builder(&adaptor, s)
+                    }),
+                }),
+            )
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -278,7 +278,7 @@ mod tests {
                     Ok(resp) => {
                         if let Ok(content) = resp.get_string(1) {
                             <TestAdaptor as HyperServerAdaptor<M>>::response_builder(
-                                &adaptor,
+                                adaptor,
                                 StatusCode::OK,
                             )
                             .body(BoxBody::new(Full::new(Bytes::from_owner(
@@ -287,7 +287,7 @@ mod tests {
                             .map_err(|e| e.into())
                         } else {
                             <TestAdaptor as HyperServerAdaptor<M>>::response_builder(
-                                &adaptor,
+                                adaptor,
                                 StatusCode::BAD_REQUEST,
                             )
                             .body(BoxBody::new(Full::new(Bytes::from("Bad Request"))))
@@ -295,7 +295,7 @@ mod tests {
                         }
                     }
                     Err(err) => default_srv_error_response(&err, |s| {
-                        <TestAdaptor as HyperServerAdaptor<M>>::response_builder(&adaptor, s)
+                        <TestAdaptor as HyperServerAdaptor<M>>::response_builder(adaptor, s)
                     }),
                 }),
             )


### PR DESCRIPTION
The adaptor previously relied on the `process_srv_response` and `process_srv_error` functions. However, these functions had a significant limitation: they lacked access to the transaction context.

By replacing them with a Closure, the response now has full access to the transaction context, improving consistency and reliability in processing.